### PR TITLE
Add WGSL shader parsing with render to preview + support for ShaderToy-style uniforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
-# Vue 3 + TypeScript + Vite
+# SplitShade - a browser-based WebGPU Playground
 
-This template should help get you started developing with Vue 3 and TypeScript in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
+This project is a work in progress. For now, I am storing some notes on my README as I go along.
 
-Learn more about the recommended Project Setup and IDE Support in the [Vue Docs TypeScript Guide](https://vuejs.org/guide/typescript/overview.html#project-setup).
+## Developer Notes
+
+This version of the playground enforces a ShaderToy-style execution model:
+- Only fragment shaders are accepted from user input.
+- A hardcoded fullscreen vertex shader is injected automatically at runtime.
+- Fragment shaders are compiled and run over the entire canvas using a triangle covering the full screen.
+- Vertex and compute entry points are still detected (via `wgsl_reflect`), but are ignored and warned about in the console.
+
+This setup ensures that users can write fragment shaders without having to define vertex logic or pipeline configuration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@fontsource/lato": "^5.2.6",
         "@guolao/vue-monaco-editor": "^1.5.5",
         "monaco-editor": "^0.52.2",
-        "vue": "^3.5.13"
+        "vue": "^3.5.13",
+        "wgsl_reflect": "^1.2.1"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.2.3",
@@ -1732,6 +1733,12 @@
       "peerDependencies": {
         "vue": "^3.0.11"
       }
+    },
+    "node_modules/wgsl_reflect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/wgsl_reflect/-/wgsl_reflect-1.2.1.tgz",
+      "integrity": "sha512-PY6MdLqLW1NFj/V6f5/9/Nb4ultwlAF7lCLyjKOAkdnlf7LlrGXNFXzHHEV7Okg1zy4C4TpBIcc/G3PXW4py8g==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "@fontsource/lato": "^5.2.6",
     "@guolao/vue-monaco-editor": "^1.5.5",
     "monaco-editor": "^0.52.2",
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "wgsl_reflect": "^1.2.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,9 +17,10 @@ const canvasRef = ref<HTMLCanvasElement | null>(null)
 const consoleOutput = ref("")
 function runShader() {
   if (canvasRef.value) {
-    consoleOutput.value = "Compiled successfully, running shader..."
+    // consoleOutput.value = "Compiled successfully, running shader..."
+    consoleOutput.value = ""
     initWebGPU(canvasRef.value, code.value, (msg) => {
-      consoleOutput.value = msg || "Compiled successfully"
+      consoleOutput.value += (msg || "Compiled successfully") + '\n'
     })
   }
 }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -12,47 +12,121 @@ fn main(@builtin(vertex_index) vertexIndex : u32) -> @builtin(position) vec4<f32
 }
 `;
 
-// TODO: clean up
+async function getWebGPUDevice() {
+  if (!navigator.gpu) {
+    console.error("WebGPU not supported.");
+    return { device: null, adapter: null };
+  }
+
+  const adapter = await navigator.gpu.requestAdapter();
+  if (!adapter) {
+    console.error("Failed to get GPU adapter");
+    return { device: null, adapter: null };
+  }
+
+  const device = await adapter.requestDevice();
+  if (!device) {
+    console.error("Failed to get GPU device");
+    return { device: null, adapter: null };
+  }
+
+  console.log("Got GPU device:", device);
+  return { device, adapter };
+}
+
+function configureCanvasContext(canvas: HTMLCanvasElement, device: GPUDevice) {
+  const context = canvas.getContext("webgpu") as GPUCanvasContext;
+  const format = navigator.gpu.getPreferredCanvasFormat();
+  context.configure({
+    device,
+    format,
+    alphaMode: "opaque",
+  });
+  return { context, format };
+}
+
+async function compileShaderModule(device: GPUDevice, code: string, output: (msg: string) => void) {
+  const module = device.createShaderModule({ code });
+
+  // Get diagnostic info
+  const info = await module.getCompilationInfo();
+  if (info.messages.length > 0) {
+    const formatted = info.messages.map(m => {
+      const where = `L${m.lineNum}:${m.linePos}`;
+      return `[${m.type}] ${where} ${m.message}`;
+    }).join("\n");
+    output(formatted);
+    if (info.messages.some(m => m.type === "error")) return null;
+  }
+  return module;
+}
+
+function createFullscreenPipeline(
+  device: GPUDevice,
+  vertexModule: GPUShaderModule,
+  fragmentModule: GPUShaderModule,
+  fragmentEntryPoint: string,
+  format: GPUTextureFormat
+) {
+  // Create render pipeline using fullscreen triangle
+  return device.createRenderPipeline({
+    layout: "auto",
+    vertex: {
+      module: vertexModule,
+      entryPoint: "main",
+    },
+    fragment: {
+      module: fragmentModule,
+      entryPoint: fragmentEntryPoint,
+      targets: [{ format }],
+    },
+    primitive: {
+      topology: "triangle-list",
+    },
+  });
+}
+
+function runRenderPass(
+  device: GPUDevice,
+  context: GPUCanvasContext,
+  pipeline: GPURenderPipeline
+) {
+  // Encode commands
+  const encoder = device.createCommandEncoder();
+  const pass = encoder.beginRenderPass({
+    colorAttachments: [{
+      view: context.getCurrentTexture().createView(),
+      clearValue: { r: 0.1, g: 0.1, b: 0.1, a: 1.0 },
+      loadOp: "clear",
+      storeOp: "store",
+    }],
+  });
+
+  pass.setPipeline(pipeline);
+  pass.draw(3); // Fullscreen triangle
+  pass.end();
+
+  device.queue.submit([encoder.finish()]);
+}
+
 // TODO: check where we are logging direct to console versus output()
 export async function initWebGPU(
   canvas: HTMLCanvasElement,
   shaderCode: string,
   onConsoleOutput?: (msg: string) => void
 ) {
-  console.log("Initializing WebGPU...");
-
   const output = (msg: string) => {
     if (onConsoleOutput) onConsoleOutput(msg); // log to browser console
     console.log(msg);                          // always log to inspect console
   };
 
+  console.log("Initializing WebGPU...");
+
   try {
-    if (!navigator.gpu) {
-      console.error("WebGPU not supported.");
-      return;
-    }
+    const { device, adapter } = await getWebGPUDevice();
+    if (!device || !adapter) return;
 
-    const adapter = await navigator.gpu.requestAdapter();
-    if (!adapter) {
-      console.error("Failed to get GPU adapter");
-      return;
-    }
-
-    const device = await adapter.requestDevice();
-    if (!device) {
-      console.error("Failed to get GPU device");
-      return;
-    }
-    console.log("Got GPU device:", device);
-
-    const context = canvas.getContext("webgpu") as GPUCanvasContext;
-    const format = navigator.gpu.getPreferredCanvasFormat();
-
-    context.configure({
-      device,
-      format,
-      alphaMode: "opaque",
-    });
+    const { context, format } = configureCanvasContext(canvas, device);
 
     const parsedCode = parseWGSL(shaderCode);
     output(`Detected shader type: ${parsedCode.type}`);
@@ -71,59 +145,16 @@ export async function initWebGPU(
     const vertexModule = device.createShaderModule({
       code: fullscreenVertexWGSL,
     });
-    const fragmentModule = device.createShaderModule({
-      code: shaderCode,
-    });
-
-    // Get diagnostic info
-    const info = await fragmentModule.getCompilationInfo();
-    if (info.messages.length > 0) {
-      const formatted = info.messages.map(m => {
-        const where = `L${m.lineNum}:${m.linePos}`;
-        return `[${m.type}] ${where} ${m.message}`;
-      }).join("\n");
-      output(formatted);
-      if (info.messages.some(m => m.type === "error")) return; // Abort if errors
-    }
+    const fragmentModule = await compileShaderModule(device, shaderCode, output);
+    if (!fragmentModule) return;
 
     // catch any validation errors that happen in this scope
     // this is useful for catching shader compilation errors
     // collect them to check later with popErrorScope()
     device.pushErrorScope('validation');
 
-    // Create render pipeline using fullscreen triangle
-    const pipeline = device.createRenderPipeline({
-      layout: "auto",
-      vertex: {
-        module: vertexModule,
-        entryPoint: "main",
-      },
-      fragment: {
-        module: fragmentModule,
-        entryPoint: parsedCode.entryPoints[0].name,
-        targets: [{ format }],
-      },
-      primitive: {
-        topology: "triangle-list",
-      },
-    });
-
-    // Encode commands
-    const encoder = device.createCommandEncoder();
-    const pass = encoder.beginRenderPass({
-      colorAttachments: [{
-        view: context.getCurrentTexture().createView(),
-        clearValue: { r: 0.1, g: 0.1, b: 0.1, a: 1.0 },
-        loadOp: "clear",
-        storeOp: "store",
-      }],
-    });
-
-    pass.setPipeline(pipeline);
-    pass.draw(3); // Fullscreen triangle
-    pass.end();
-
-    device.queue.submit([encoder.finish()]);
+    const pipeline = createFullscreenPipeline(device, vertexModule, fragmentModule, parsedCode.entryPoints[0].name, format);
+    runRenderPass(device, context, pipeline);
 
     // Pop error scope
     const error = await device.popErrorScope();

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,5 +1,19 @@
 import { parseWGSL } from './webgpu/parser';
 
+const fullscreenVertexWGSL = `
+@vertex
+fn main(@builtin(vertex_index) vertexIndex : u32) -> @builtin(position) vec4<f32> {
+  var pos = array<vec2<f32>, 3>(
+    vec2<f32>(-1.0, -3.0),
+    vec2<f32>(3.0, 1.0),
+    vec2<f32>(-1.0, 1.0)
+  );
+  return vec4<f32>(pos[vertexIndex], 0.0, 1.0);
+}
+`;
+
+// TODO: clean up
+// TODO: check where we are logging direct to console versus output()
 export async function initWebGPU(
   canvas: HTMLCanvasElement,
   shaderCode: string,
@@ -8,9 +22,9 @@ export async function initWebGPU(
   console.log("Initializing WebGPU...");
 
   const output = (msg: string) => {
-    if (onConsoleOutput) onConsoleOutput(msg) // log to browser console
-    console.log(msg)                          // always log to inspect console
-  }
+    if (onConsoleOutput) onConsoleOutput(msg); // log to browser console
+    console.log(msg);                          // always log to inspect console
+  };
 
   try {
     if (!navigator.gpu) {
@@ -31,11 +45,6 @@ export async function initWebGPU(
     }
     console.log("Got GPU device:", device);
 
-    // catch any validation errors that happen in this scope
-    // this is useful for catching shader compilation errors
-    // collect them to check later with popErrorScope()
-    device.pushErrorScope('validation');
-
     const context = canvas.getContext("webgpu") as GPUCanvasContext;
     const format = navigator.gpu.getPreferredCanvasFormat();
 
@@ -46,18 +55,28 @@ export async function initWebGPU(
     });
 
     const parsedCode = parseWGSL(shaderCode);
-    console.log(`Detected shader type: ${parsedCode.type}`);
-    if (parsedCode.type === 'error') {
-      output(`Shader parsedCode error: ${parsedCode.error}`);
+    output(`Detected shader type: ${parsedCode.type}`);
+
+    if (!parsedCode.valid) {
+      // log the most relevant error message
+      output(parsedCode.message || parsedCode.error || 'Invalid shader.');
       return;
     }
 
-    const shaderModule = device.createShaderModule({
+    if (parsedCode.warnings?.length) {
+      parsedCode.warnings.forEach(output);
+    }
+
+    // Compile fragment and hardcoded vertex shader
+    const vertexModule = device.createShaderModule({
+      code: fullscreenVertexWGSL,
+    });
+    const fragmentModule = device.createShaderModule({
       code: shaderCode,
     });
 
     // Get diagnostic info
-    const info = await shaderModule.getCompilationInfo();
+    const info = await fragmentModule.getCompilationInfo();
     if (info.messages.length > 0) {
       const formatted = info.messages.map(m => {
         const where = `L${m.lineNum}:${m.linePos}`;
@@ -67,69 +86,54 @@ export async function initWebGPU(
       if (info.messages.some(m => m.type === "error")) return; // Abort if errors
     }
 
+    // catch any validation errors that happen in this scope
+    // this is useful for catching shader compilation errors
+    // collect them to check later with popErrorScope()
+    device.pushErrorScope('validation');
+
+    // Create render pipeline using fullscreen triangle
+    const pipeline = device.createRenderPipeline({
+      layout: "auto",
+      vertex: {
+        module: vertexModule,
+        entryPoint: "main",
+      },
+      fragment: {
+        module: fragmentModule,
+        entryPoint: parsedCode.entryPoints[0].name,
+        targets: [{ format }],
+      },
+      primitive: {
+        topology: "triangle-list",
+      },
+    });
+
+    // Encode commands
     const encoder = device.createCommandEncoder();
-    if (parsedCode.type === 'render') {
-      const pipeline = device.createRenderPipeline({
-        layout: "auto",
-        vertex: {
-          module: shaderModule,
-          entryPoint: parsedCode.entryPoints.vertex[0].name,
-        },
-        fragment: {
-          module: shaderModule,
-          entryPoint: parsedCode.entryPoints.fragment[0].name,
-          targets: [{ format }],
-        },
-        primitive: {
-          topology: "triangle-list",
-        },
-      });
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [{
+        view: context.getCurrentTexture().createView(),
+        clearValue: { r: 0.1, g: 0.1, b: 0.1, a: 1.0 },
+        loadOp: "clear",
+        storeOp: "store",
+      }],
+    });
 
-      const pass = encoder.beginRenderPass({
-        colorAttachments: [{
-          view: context.getCurrentTexture().createView(),
-          clearValue: { r: 0.1, g: 0.1, b: 0.1, a: 1.0 },
-          loadOp: "clear",
-          storeOp: "store",
-        }],
-      });
-
-      pass.setPipeline(pipeline);
-      pass.draw(3); // 3 verts to make 1 triangle
-      pass.end();
-    }
-    else if (parsedCode.type === 'compute') {
-      const entryPoint = parsedCode.entryPoints[0].name;
-      // const workgroupSize = parsedCode.entryPoints[0].workgroup_size || [1, 1, 1];
-
-      const pipeline = device.createComputePipeline({
-        layout: "auto",
-        compute: {
-          module: shaderModule,
-          entryPoint,
-        }
-      });
-
-      const pass = encoder.beginComputePass();
-      pass.setPipeline(pipeline);
-      pass.dispatchWorkgroups(1, 1, 1); // Later: match canvas/grid size
-      pass.end();
-    } else {
-      output(`Unsupported shader type: ${parsedCode.type}. No pipeline created.`);
-      return;
-    }
+    pass.setPipeline(pipeline);
+    pass.draw(3); // Fullscreen triangle
+    pass.end();
 
     device.queue.submit([encoder.finish()]);
 
     // Pop error scope
     const error = await device.popErrorScope();
     if (error) {
-      output(`WebGPU Error: ${error.message}`)
+      output(`WebGPU Error: ${error.message}`);
     } else {
-      output(`Shader compiled and executed successfully.`)
+      output(`Shader compiled and executed successfully.`);
     }
-    // console.log("Submitted WebGPU draw call");
+
   } catch (err: any) {
-    output(`Caught Exception: ${err.message || err}`)
+    output(`Caught Exception: ${err.message || err}`);
   }
 }

--- a/src/shaders/mousePointerTest.wgsl
+++ b/src/shaders/mousePointerTest.wgsl
@@ -1,0 +1,23 @@
+@group(0) @binding(0)
+var<uniform> iResolution: vec3<f32>;
+
+@group(0) @binding(1)
+var<uniform> iTime: f32;
+
+@group(0) @binding(2)
+var<uniform> iMouse: vec4<f32>;
+
+@fragment
+fn main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
+  let uv = pos.xy / iResolution.xy;
+  let mouseUV = iMouse.xy / iResolution.xy;
+
+  let dist = distance(uv, mouseUV);
+  let circle = smoothstep(0.05, 0.01, dist); // soft circular falloff
+
+  let base = vec3<f32>(uv, 0.3);
+  let highlight = vec3<f32>(1.0, 1.0, 1.0);
+
+  let color = mix(base, highlight, circle);
+  return vec4<f32>(color, 1.0);
+}

--- a/src/shaders/pulsingColours-timeTest.wgsl
+++ b/src/shaders/pulsingColours-timeTest.wgsl
@@ -1,0 +1,11 @@
+@group(0) @binding(0)
+var<uniform> iResolution: vec3<f32>;
+@group(0) @binding(1)
+var<uniform> iTime: f32;
+
+@fragment
+fn main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
+  let uv = pos.xy / iResolution.xy;
+  let pulse = 0.5 + 0.5 * sin(iTime * 2.0 + uv.x * 10.0);
+  return vec4<f32>(pulse, uv.y, 0.3, 1.0);
+}

--- a/src/shaders/whiteCircle-resolutionTest.wgsl
+++ b/src/shaders/whiteCircle-resolutionTest.wgsl
@@ -1,0 +1,15 @@
+@group(0) @binding(0)
+var<uniform> iResolution: vec3<f32>;
+
+@fragment
+fn main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
+  let uv = pos.xy / iResolution.xy;
+  let center = vec2<f32>(0.5, 0.5);
+  let radius = 0.2;
+  let d = distance(uv, center);
+  if (d < radius) {
+    return vec4<f32>(1.0, 1.0, 1.0, 1.0);
+  } else {
+    return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+  };
+}

--- a/src/webgpu/parser.ts
+++ b/src/webgpu/parser.ts
@@ -1,0 +1,18 @@
+import { WgslReflect } from 'wgsl_reflect';
+
+export function parseWGSL(wgslCode: string) {
+  try {
+    const reflect = new WgslReflect(wgslCode);
+    const entries = reflect.entry;
+
+    if (entries.compute.length > 0) {
+      return { type: 'compute', entryPoints: entries.compute };
+    } else if (entries.vertex.length > 0 && entries.fragment.length > 0) {
+      return { type: 'render', entryPoints: { vertex: entries.vertex, fragment: entries.fragment } };
+    } else {
+      return { type: 'unknown', entryPoints: {} };
+    }
+  } catch (err) {
+    return { type: 'error', error: err.message };
+  }
+}


### PR DESCRIPTION
This PR introduces WGSL parsing using [`wgsl_reflect`](https://github.com/brendan-duncan/wgsl_reflect) to automatically detect shader types and entry points. It also adds support for commonly used ShaderToy-style uniforms (`iResolution`, `iTime`, `iMouse`) and includes example shaders to demonstrate each one.

## What's New

- **Shader Parsing via `wgsl_reflect`**
  - Automatically detects shader type: fragment, vertex, or compute.
  - Extracts entry point information from the WGSL source.
  - Currently limited to fragment shaders; vertex is auto-injected.

- **`iResolution` Uniform**
  - Injects a `vec3<f32>` representing the canvas width, height, and 1.0.

- **`iTime` Uniform**
  - Provides the time in seconds since the render loop began.

- **`iMouse` Uniform**
  - Tracks mouse position (in canvas pixel space) and click state as a `vec4<f32>`.

- **Shader Examples**
  - `whiteCircle-resolutionTest.wgsl`: Uses `iResolution`
  - `pulsingColours-timeTest.wgsl`: Uses `iTime`
  - `mousePointerTest.wgsl`: Uses `iMouse`

- **Code Cleanup**
  - Refactored canvas, pipeline, and uniform setup into helper functions.
  - Centralized logging and shader module compilation.

## Notes

- Only fragment shaders are allowed in the editor; vertex shaders are injected automatically.
- Errors are caught and logged using `getCompilationInfo()` and WebGPU validation scopes.
- The uniforms are updated per-frame using `requestAnimationFrame`.

## Potential Next Steps

- Deploy to Github Pages
- Add support for compute and vertex shader execution.
- Add live-reloading or inline error annotation in the editor.